### PR TITLE
Support Ctrl-Z and Suspension (SIGTSTP) Generally

### DIFF
--- a/common.go
+++ b/common.go
@@ -34,6 +34,7 @@ type commonState struct {
 	shouldRestart     ShouldRestart
 	noBeep            bool
 	needRefresh       bool
+	suspendFn         func()
 }
 
 // TabStyle is used to select how tab completions are displayed.
@@ -248,6 +249,15 @@ func (s *State) SetShouldRestart(f ShouldRestart) {
 // ASCII BEL, 0x07). Default is true (will beep).
 func (s *State) SetBeep(beep bool) {
 	s.noBeep = !beep
+}
+
+// SetSuspendFn sets the function to call when Ctrl-Z (^Z) is seen on
+// input.  If nil, ^Z is ignored. Else, the function is called
+// (without echoing "^Z\n", which the function can do if desired) and,
+// if and when it returns (due to SIGCONT), the input line is
+// refreshed.
+func (s *State) SetSuspendFn(f func()) {
+	s.suspendFn = f
 }
 
 func (s *State) promptUnsupported(p string) (string, error) {

--- a/common.go
+++ b/common.go
@@ -252,10 +252,12 @@ func (s *State) SetBeep(beep bool) {
 }
 
 // SetSuspendFn sets the function to call when Ctrl-Z (^Z) is seen on
-// input.  If nil, ^Z is ignored. Else, the function is called
-// (without echoing "^Z\n", which the function can do if desired) and,
-// if and when it returns (due to SIGCONT), the input line is
-// refreshed.
+// input.  If nil (the default), ^Z is ignored. Else, the function is
+// called (without echoing "^Z\n", which the function can do if
+// desired) and, if and when it returns (due to SIGCONT), the input
+// line is refreshed. The function should call s.Suspend() before
+// proceeding with the suspension (via SIGSTOP) and, if and when
+// SIGCONT continues the process, call s.Continue().
 func (s *State) SetSuspendFn(f func()) {
 	s.suspendFn = f
 }

--- a/input.go
+++ b/input.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 )
@@ -349,19 +348,6 @@ func (s *State) readNext() (interface{}, error) {
 
 	// not reached
 	return r, nil
-}
-
-func (s *State) sleepToResume() {
-	if !atomic.CompareAndSwapInt32(&s.sleeping, 0, 1) {
-		return
-	}
-	defer atomic.StoreInt32(&s.sleeping, 0)
-
-	s.ExitRawMode()
-	ch := WaitForResume()
-	SuspendMe()
-	<-ch
-	s.EnterRawMode()
 }
 
 // Close returns the terminal to its previous mode

--- a/line.go
+++ b/line.go
@@ -859,11 +859,15 @@ mainLoop:
 			case tab: // Tab completion
 				line, pos, next, err = s.tabComplete(p, line, pos)
 				goto haveNext
+			case ctrlZ:
+				fmt.Println("^Z")
+				s.sleepToResume()
+				s.needRefresh = true
 			// Catch keys that do nothing, but you don't want them to beep
 			case esc:
 				// DO NOTHING
 			// Unused keys
-			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX, ctrlZ:
+			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:

--- a/line.go
+++ b/line.go
@@ -327,6 +327,7 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 
 		if numTabs == 2 {
 			if len(items) > 100 {
+			restart:
 				fmt.Printf("\nDisplay all %d possibilities? (y or n) ", len(items))
 			prompt:
 				for {
@@ -348,6 +349,7 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 								s.doBeep()
 							} else {
 								s.suspendFn()
+								goto restart
 							}
 						}
 					}
@@ -876,7 +878,7 @@ mainLoop:
 					s.doBeep()
 				} else {
 					s.suspendFn()
-					s.needRefresh = true
+					goto restart
 				}
 			// Catch keys that do nothing, but you don't want them to beep
 			case esc:
@@ -1164,7 +1166,7 @@ mainLoop:
 					s.doBeep()
 				} else {
 					s.suspendFn()
-					s.restartPrompt()
+					goto restart
 				}
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,

--- a/line.go
+++ b/line.go
@@ -343,6 +343,12 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 							break prompt
 						case ctrlC, ctrlD, cr, lf:
 							s.restartPrompt()
+						case ctrlZ:
+							if s.suspendFn == nil {
+								s.doBeep()
+							} else {
+								s.suspendFn()
+							}
 						}
 					}
 				}
@@ -490,8 +496,14 @@ func (s *State) reverseISearch(origLine []rune, origPos int) ([]rune, int, inter
 			case ctrlG: // Cancel
 				return origLine, origPos, rune(esc), err
 
+			case ctrlZ:
+				if s.suspendFn == nil {
+					s.doBeep()
+				} else {
+					s.suspendFn()
+				}
 			case tab, cr, lf, ctrlA, ctrlB, ctrlD, ctrlE, ctrlF, ctrlK,
-				ctrlL, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY, ctrlZ:
+				ctrlL, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
 			case 0, ctrlC, esc, 28, 29, 30, 31:
 				return []rune(foundLine), foundPos, next, err
@@ -860,9 +872,12 @@ mainLoop:
 				line, pos, next, err = s.tabComplete(p, line, pos)
 				goto haveNext
 			case ctrlZ:
-				fmt.Println("^Z")
-				s.sleepToResume()
-				s.needRefresh = true
+				if s.suspendFn == nil {
+					s.doBeep()
+				} else {
+					s.suspendFn()
+					s.needRefresh = true
+				}
 			// Catch keys that do nothing, but you don't want them to beep
 			case esc:
 				// DO NOTHING
@@ -1144,9 +1159,16 @@ mainLoop:
 				pos = 0
 				fmt.Print(prompt)
 				s.restartPrompt()
+			case ctrlZ:
+				if s.suspendFn == nil {
+					s.doBeep()
+				} else {
+					s.suspendFn()
+					s.restartPrompt()
+				}
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,
-				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY, ctrlZ:
+				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:

--- a/line.go
+++ b/line.go
@@ -878,7 +878,7 @@ mainLoop:
 					s.doBeep()
 				} else {
 					s.suspendFn()
-					goto restart
+					s.needRefresh = true
 				}
 			// Catch keys that do nothing, but you don't want them to beep
 			case esc:
@@ -1166,7 +1166,7 @@ mainLoop:
 					s.doBeep()
 				} else {
 					s.suspendFn()
-					goto restart
+					s.needRefresh = true
 				}
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,


### PR DESCRIPTION
This approach involves fairly minimal changes to `liner`, leaving handling of `SIGTSTP` and such to the client, which might have other actions to perform.

While synchronous suspension (Ctrl-Z seen as input) seems to work in the normal-prompt, display-many-prompt, and reverse-search cases I tested, I haven't tested password or other input (though it should work similarly).

However, asynchronous suspension (another process sending `SIGTSTP`) doesn't continue as cleanly as synchronous (though things seem to right themselves after a line of input). That's probably due to the code being deeper into reading a character when suspension happens. A more-sophisticated approach might involve feeding a "restart-this" object into the input pipeline in this situation; not sure that's worth the trouble, though.