### PR TITLE
Use Raw Mode Only When Reading and Support Ctrl-Z and Ctrl-\

### DIFF
--- a/input.go
+++ b/input.go
@@ -117,7 +117,7 @@ func (s *State) stopPrompt() {
 }
 
 func (s *State) suspendFn() {
-	fmt.Println("^Z [liner]")
+	fmt.Println("^Z")
 	s.exitRawMode()
 	cont := make(chan os.Signal, 1)
 	signal.Notify(cont, syscall.SIGCONT)
@@ -127,7 +127,7 @@ func (s *State) suspendFn() {
 }
 
 func (s *State) quitFn() {
-	fmt.Println("^\\ [liner]")
+	fmt.Println("^\\")
 	s.exitRawMode()
 	// There's no reason to expect a SIGCONT, but by waiting for
 	// one anyway, the return to raw mode is avoided before the

--- a/input.go
+++ b/input.go
@@ -5,6 +5,7 @@ package liner
 import (
 	"bufio"
 	"errors"
+	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
@@ -48,12 +49,6 @@ func NewLiner() *State {
 		s.terminalSupported = false
 	}
 	if s.terminalSupported && !s.inputRedirected && !s.outputRedirected {
-		mode := s.origMode
-		mode.Iflag &^= icrnl | inpck | istrip | ixon
-		mode.Cflag |= cs8
-		mode.Lflag &^= syscall.ECHO | icanon | iexten
-		mode.ApplyMode()
-
 		winch := make(chan os.Signal, 1)
 		signal.Notify(winch, syscall.SIGWINCH)
 		s.winch = winch
@@ -68,17 +63,31 @@ func NewLiner() *State {
 	return &s
 }
 
-var errTimedOut = errors.New("timeout")
-
-func (s *State) startPrompt() {
+func (s *State) enterRawMode() {
 	if s.terminalSupported {
 		if m, err := TerminalMode(); err == nil {
 			s.defaultMode = *m.(*termios)
 			mode := s.defaultMode
-			mode.Lflag &^= isig
+			mode.Iflag &^= icrnl | inpck | istrip | ixon
+			mode.Cflag |= cs8
+			mode.Lflag &^= syscall.ECHO | isig | icanon | iexten
+			mode.Cc[syscall.VMIN] = 1
+			mode.Cc[syscall.VTIME] = 0
 			mode.ApplyMode()
 		}
 	}
+}
+
+func (s *State) exitRawMode() {
+	if s.terminalSupported {
+		s.defaultMode.ApplyMode()
+	}
+}
+
+var errTimedOut = errors.New("timeout")
+
+func (s *State) startPrompt() {
+	s.enterRawMode()
 	s.restartPrompt()
 }
 
@@ -104,9 +113,27 @@ func (s *State) restartPrompt() {
 }
 
 func (s *State) stopPrompt() {
-	if s.terminalSupported {
-		s.defaultMode.ApplyMode()
-	}
+	s.exitRawMode()
+}
+
+func (s *State) suspendFn() {
+	fmt.Println("^Z [liner]")
+	s.exitRawMode()
+	cont := make(chan os.Signal, 1)
+	signal.Notify(cont, syscall.SIGCONT)
+	//	p, _ := os.FindProcess(os.Getppid())  // Needed on OS X (Darwin) only?
+	//	p.Signal(syscall.SIGTSTP)  // Needed on OS X (Darwin) only?
+	syscall.Kill(syscall.Getpid(), syscall.SIGTSTP)
+	<-cont
+	s.enterRawMode()
+}
+
+func echoEOF() {
+	fmt.Println("^D")
+}
+
+func mapRune(r rune) rune {
+	return r
 }
 
 func (s *State) nextPending(timeout <-chan time.Time) (rune, error) {

--- a/input.go
+++ b/input.go
@@ -121,6 +121,7 @@ func (s *State) suspendFn() {
 	s.exitRawMode()
 	cont := make(chan os.Signal, 1)
 	signal.Notify(cont, syscall.SIGCONT)
+	defer func() { signal.Stop(cont) }()
 	syscall.Kill(syscall.Getpid(), syscall.SIGTSTP)
 	<-cont
 	s.enterRawMode()

--- a/input_windows.go
+++ b/input_windows.go
@@ -2,6 +2,7 @@ package liner
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"syscall"
 	"unicode/utf16"
@@ -342,8 +343,8 @@ func echoEOF() {
 
 func mapRune(r rune) rune {
 	switch r {
-	case CtrlZ:
-		r = CtrlD
+	case ctrlZ:
+		r = ctrlD
 	}
 	return r
 }

--- a/input_windows.go
+++ b/input_windows.go
@@ -65,13 +65,6 @@ func NewLiner() *State {
 	s.terminalSupported = true
 	if m, err := TerminalMode(); err == nil {
 		s.origMode = m.(inputMode)
-		mode := s.origMode
-		mode &^= enableEchoInput
-		mode &^= enableInsertMode
-		mode &^= enableLineInput
-		mode &^= enableMouseInput
-		mode |= enableWindowInput
-		mode.ApplyMode()
 	} else {
 		s.inputRedirected = true
 		s.r = bufio.NewReader(os.Stdin)
@@ -318,6 +311,11 @@ func (s *State) startPrompt() {
 	if m, err := TerminalMode(); err == nil {
 		s.defaultMode = m.(inputMode)
 		mode := s.defaultMode
+		mode &^= enableEchoInput
+		mode &^= enableInsertMode
+		mode &^= enableLineInput
+		mode &^= enableMouseInput
+		mode |= enableWindowInput
 		mode &^= enableProcessedInput
 		mode.ApplyMode()
 	}
@@ -328,6 +326,22 @@ func (s *State) restartPrompt() {
 
 func (s *State) stopPrompt() {
 	s.defaultMode.ApplyMode()
+}
+
+func (s *State) suspendFn() {
+	fmt.Println("^Z [unsupported on Windows]")
+}
+
+func echoEOF() {
+	fmt.Println("^Z")
+}
+
+func mapRune(r rune) rune {
+	switch r {
+	case CtrlZ:
+		r = CtrlD
+	}
+	return r
 }
 
 // TerminalSupported returns true because line editing is always

--- a/input_windows.go
+++ b/input_windows.go
@@ -332,6 +332,10 @@ func (s *State) suspendFn() {
 	fmt.Println("^Z [unsupported on Windows]")
 }
 
+func (s *State) quitFn() {
+	fmt.Println("^\\ [unsupported on Windows]")
+}
+
 func echoEOF() {
 	fmt.Println("^Z")
 }

--- a/line.go
+++ b/line.go
@@ -731,7 +731,11 @@ mainLoop:
 			case ctrlD: // del
 				if pos == 0 && len(line) == 0 {
 					// exit
-					echoEOF()
+					if v == ctrlD {
+						fmt.Println("^D")
+					} else {
+						echoEOF() // Print OS-specific string ("^Z" on Windows)
+					}
 					return "", io.EOF
 				}
 

--- a/line.go
+++ b/line.go
@@ -52,34 +52,35 @@ const (
 )
 
 const (
-	ctrlA = 1
-	ctrlB = 2
-	ctrlC = 3
-	ctrlD = 4
-	ctrlE = 5
-	ctrlF = 6
-	ctrlG = 7
-	ctrlH = 8
-	tab   = 9
-	lf    = 10
-	ctrlK = 11
-	ctrlL = 12
-	cr    = 13
-	ctrlN = 14
-	ctrlO = 15
-	ctrlP = 16
-	ctrlQ = 17
-	ctrlR = 18
-	ctrlS = 19
-	ctrlT = 20
-	ctrlU = 21
-	ctrlV = 22
-	ctrlW = 23
-	ctrlX = 24
-	ctrlY = 25
-	ctrlZ = 26
-	esc   = 27
-	bs    = 127
+	ctrlA         = 1
+	ctrlB         = 2
+	ctrlC         = 3
+	ctrlD         = 4
+	ctrlE         = 5
+	ctrlF         = 6
+	ctrlG         = 7
+	ctrlH         = 8
+	tab           = 9
+	lf            = 10
+	ctrlK         = 11
+	ctrlL         = 12
+	cr            = 13
+	ctrlN         = 14
+	ctrlO         = 15
+	ctrlP         = 16
+	ctrlQ         = 17
+	ctrlR         = 18
+	ctrlS         = 19
+	ctrlT         = 20
+	ctrlU         = 21
+	ctrlV         = 22
+	ctrlW         = 23
+	ctrlX         = 24
+	ctrlY         = 25
+	ctrlZ         = 26
+	esc           = 27
+	ctrlBackslash = 28
+	bs            = 127
 )
 
 const (
@@ -347,6 +348,9 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 						case ctrlZ:
 							s.suspendFn()
 							goto restart
+						case ctrlBackslash:
+							s.quitFn()
+							goto restart
 						}
 					}
 				}
@@ -496,10 +500,12 @@ func (s *State) reverseISearch(origLine []rune, origPos int) ([]rune, int, inter
 
 			case ctrlZ:
 				s.suspendFn()
+			case ctrlBackslash:
+				s.quitFn()
 			case tab, cr, lf, ctrlA, ctrlB, ctrlD, ctrlE, ctrlF, ctrlK,
 				ctrlL, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
-			case 0, ctrlC, esc, 28, 29, 30, 31:
+			case 0, ctrlC, esc, 29, 30, 31:
 				return []rune(foundLine), foundPos, next, err
 			default:
 				line = append(line[:pos], append([]rune{v}, line[pos:]...)...)
@@ -869,6 +875,9 @@ mainLoop:
 			case ctrlZ:
 				s.suspendFn()
 				s.needRefresh = true
+			case ctrlBackslash:
+				s.quitFn()
+				s.needRefresh = true
 			// Catch keys that do nothing, but you don't want them to beep
 			case esc:
 				// DO NOTHING
@@ -876,7 +885,7 @@ mainLoop:
 			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
-			case 0, 28, 29, 30, 31:
+			case 0, 29, 30, 31:
 				s.doBeep()
 			default:
 				if pos == len(line) && !s.multiLineMode &&
@@ -1153,12 +1162,15 @@ mainLoop:
 			case ctrlZ:
 				s.suspendFn()
 				s.needRefresh = true
+			case ctrlBackslash:
+				s.quitFn()
+				s.needRefresh = true
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,
 				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
-			case 0, 28, 29, 30, 31:
+			case 0, 29, 30, 31:
 				s.doBeep()
 			default:
 				line = append(line[:pos], append([]rune{v}, line[pos:]...)...)

--- a/line.go
+++ b/line.go
@@ -327,6 +327,7 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 
 		if numTabs == 2 {
 			if len(items) > 100 {
+			restart:
 				fmt.Printf("\nDisplay all %d possibilities? (y or n) ", len(items))
 			prompt:
 				for {
@@ -343,6 +344,9 @@ func (s *State) printedTabs(items []string) func(tabDirection) (string, error) {
 							break prompt
 						case ctrlC, ctrlD, cr, lf:
 							s.restartPrompt()
+						case ctrlZ:
+							s.suspendFn()
+							goto restart
 						}
 					}
 				}
@@ -490,8 +494,10 @@ func (s *State) reverseISearch(origLine []rune, origPos int) ([]rune, int, inter
 			case ctrlG: // Cancel
 				return origLine, origPos, rune(esc), err
 
+			case ctrlZ:
+				s.suspendFn()
 			case tab, cr, lf, ctrlA, ctrlB, ctrlD, ctrlE, ctrlF, ctrlK,
-				ctrlL, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY, ctrlZ:
+				ctrlL, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
 			case 0, ctrlC, esc, 28, 29, 30, 31:
 				return []rune(foundLine), foundPos, next, err
@@ -669,7 +675,7 @@ mainLoop:
 		historyAction = false
 		switch v := next.(type) {
 		case rune:
-			switch v {
+			switch mapRune(v) {
 			case '(', '[', '{', '"':
 				if s.inputWaiting() {
 					line = append(line[:pos], append([]rune{v}, line[pos:]...)...)
@@ -719,6 +725,7 @@ mainLoop:
 			case ctrlD: // del
 				if pos == 0 && len(line) == 0 {
 					// exit
+					echoEOF()
 					return "", io.EOF
 				}
 
@@ -859,11 +866,14 @@ mainLoop:
 			case tab: // Tab completion
 				line, pos, next, err = s.tabComplete(p, line, pos)
 				goto haveNext
+			case ctrlZ:
+				s.suspendFn()
+				s.needRefresh = true
 			// Catch keys that do nothing, but you don't want them to beep
 			case esc:
 				// DO NOTHING
 			// Unused keys
-			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX, ctrlZ:
+			case ctrlG, ctrlO, ctrlQ, ctrlS, ctrlV, ctrlX:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:
@@ -1092,7 +1102,7 @@ mainLoop:
 
 		switch v := next.(type) {
 		case rune:
-			switch v {
+			switch mapRune(v) {
 			case cr, lf:
 				if s.needRefresh {
 					err := s.refresh(p, line, pos)
@@ -1140,9 +1150,12 @@ mainLoop:
 				pos = 0
 				fmt.Print(prompt)
 				s.restartPrompt()
+			case ctrlZ:
+				s.suspendFn()
+				s.needRefresh = true
 			// Unused keys
 			case esc, tab, ctrlA, ctrlB, ctrlE, ctrlF, ctrlG, ctrlK, ctrlN, ctrlO, ctrlP, ctrlQ, ctrlR, ctrlS,
-				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY, ctrlZ:
+				ctrlT, ctrlU, ctrlV, ctrlW, ctrlX, ctrlY:
 				fallthrough
 			// Catch unhandled control codes (anything <= 31)
 			case 0, 28, 29, 30, 31:


### PR DESCRIPTION
Per discussion in https://github.com/candid82/liner/pull/1, this seems to tick all the necessary boxes:

- "Raw" mode is entered only when prompting for and reading input, and the previous mode is restored before returning the input line to the client
- `(joker.core/read-line)` thus works within the REPL just as it does outside of it (terminal runs in the original mode, or whatever mode is established by the client)
- Control-Z and Control-\ are recognized while in raw mode and handled by restoring the previous mode, raising the pertinent signal (`SIGTSTP` or `SIGQUIT`), awaiting a `SIGCONT` (if it ever comes), then returning to raw mode, refreshing the pending line(s) of input, and continuing as before
- No changes are required to Joker itself, just as the `readline` package didn't require any
- Joker (or any client) is free to catch `SIGTSTP` and handle it (the terminal would be in canonical mode at this point), just as the Go runtime catches `SIGQUIT` and handles that

Tested (in ad-hoc fashion) on Ubuntu Linux, Mac OS X, and Windows 7.