### PR TITLE
Correcting example in README to import your liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/peterh/liner"
+	"github.com/candid82/liner"
 )
 
 var (


### PR DESCRIPTION
The README has code that imports peterh's liner instead of this one.